### PR TITLE
Fix JDBC URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ Uses H2 in-memory database. Data will be reset when the application restarts.
 H2 Console is accessible at http://localhost:8080/h2-console
 
 ### Connection Details
-- JDBC URL: `jdbc:h2:mem:todoapp`
+- JDBC URL: `jdbc:h2:mem:app_dev`
 - User Name: `sa`
 - Password: (leave blank)


### PR DESCRIPTION
## Summary
- Corrected H2 database JDBC URL in README.md to match actual configuration
- Changed from `jdbc:h2:mem:todoapp` to `jdbc:h2:mem:app_dev`

## Changes
- Updated Connection Details section in README.md to reflect the correct database name used in `application-dev.yml`

🤖 Generated with [Claude Code](https://claude.ai/code)