### PR TITLE
Update workflows to trigger on pull request events

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -3,15 +3,14 @@ run-name: "Build Backend : ${{ github.event.head_commit.message }}"
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - develop
-      - feature/*
-    tags:
-      - v*
+  pull_request:
+    types: [opened, synchronize, reopened]
     paths:
       - backend/**
       - .github/workflows/build-backend.yml
+  push:
+    tags:
+      - v*
 
 env:
   DOCKER_IMAGE_NAME: yamac-net-claude-code-todoapp/backend
@@ -19,7 +18,6 @@ env:
 jobs:
   build:
     runs-on: arc-runner-set
-    if: startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout
@@ -48,8 +46,8 @@ jobs:
         with:
           driver: docker
 
-      - name: Docker Build and Push on develop
-        if: startsWith(github.ref, 'refs/heads/develop')
+      - name: Docker Build and Push on Pull Request
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           network: host
@@ -57,18 +55,7 @@ jobs:
           target: package-app
           push: true
           tags: |
-            ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:develop
-
-      - name: Docker Build and Push on feature/*
-        if: startsWith(github.ref, 'refs/heads/feature/')
-        uses: docker/build-push-action@v6
-        with:
-          network: host
-          context: backend
-          target: package-app
-          push: true
-          tags: |
-            ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:feature
+            ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:pr-${{ github.event.number }}
 
       - name: Docker Build and Push on tags
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -3,15 +3,14 @@ run-name: "Build Frontend : ${{ github.event.head_commit.message }}"
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - develop
-      - feature/*
-    tags:
-      - v*
+  pull_request:
+    types: [opened, synchronize, reopened]
     paths:
       - frontend/**
       - .github/workflows/build-frontend.yml
+  push:
+    tags:
+      - v*
 
 env:
   DOCKER_IMAGE_NAME: yamac-net-claude-code-todoapp/frontend
@@ -19,7 +18,6 @@ env:
 jobs:
   build:
     runs-on: arc-runner-set
-    if: startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout
@@ -48,8 +46,8 @@ jobs:
         with:
           driver: docker
 
-      - name: Docker Build and Push on develop
-        if: startsWith(github.ref, 'refs/heads/develop')
+      - name: Docker Build and Push on Pull Request
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           network: host
@@ -57,18 +55,7 @@ jobs:
           target: package-app-beta
           push: true
           tags: |
-            ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:develop
-
-      - name: Docker Build and Push on feature/*
-        if: startsWith(github.ref, 'refs/heads/feature/')
-        uses: docker/build-push-action@v6
-        with:
-          network: host
-          context: frontend
-          target: package-app-beta
-          push: true
-          tags: |
-            ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:feature
+            ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:pr-${{ github.event.number }}
 
       - name: Docker Build and Push on tags
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
- Change GitHub Actions workflows from push-based to pull_request-based triggers
- Workflows now execute on PR creation, synchronization, and reopening
- Simplify Docker build strategy with PR-specific tags

## Changes
- Modified `build-backend.yml` and `build-frontend.yml` triggers
- Replaced push triggers with `pull_request: types: [opened, synchronize, reopened]`
- Use Docker tag format `:pr-{number}` for PR builds
- Removed branch-specific build steps (develop/feature)
- Kept `workflow_dispatch` and `tags` triggers for manual execution and releases

## Benefits
- CI/CD runs only when PRs are created or updated
- Better resource utilization - no builds on direct pushes
- PR-specific Docker images for testing
- Cleaner workflow execution model

🤖 Generated with [Claude Code](https://claude.ai/code)