### PR TITLE
Add develop branch push trigger for :develop tag builds

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -9,6 +9,8 @@ on:
       - backend/**
       - .github/workflows/build-backend.yml
   push:
+    branches:
+      - develop
     tags:
       - v*
 
@@ -56,6 +58,17 @@ jobs:
           push: true
           tags: |
             ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:pr-${{ github.event.number }}
+
+      - name: Docker Build and Push on develop
+        if: github.ref == 'refs/heads/develop'
+        uses: docker/build-push-action@v6
+        with:
+          network: host
+          context: backend
+          target: package-app
+          push: true
+          tags: |
+            ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:develop
 
       - name: Docker Build and Push on tags
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -9,6 +9,8 @@ on:
       - frontend/**
       - .github/workflows/build-frontend.yml
   push:
+    branches:
+      - develop
     tags:
       - v*
 
@@ -56,6 +58,17 @@ jobs:
           push: true
           tags: |
             ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:pr-${{ github.event.number }}
+
+      - name: Docker Build and Push on develop
+        if: github.ref == 'refs/heads/develop'
+        uses: docker/build-push-action@v6
+        with:
+          network: host
+          context: frontend
+          target: package-app-beta
+          push: true
+          tags: |
+            ${{ vars.REGISTRY_HOST }}/${{ env.DOCKER_IMAGE_NAME }}:develop
 
       - name: Docker Build and Push on tags
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
- Add push trigger for develop branch to restore :develop tag builds
- Workflows now build Docker images when PRs are merged to develop
- Maintain existing pull_request triggers for PR validation

## Changes
- Added `push: branches: [develop]` trigger to both workflows
- Added "Docker Build and Push on develop" steps
- Backend builds with `package-app` target and `:develop` tag
- Frontend builds with `package-app-beta` target and `:develop` tag

## Workflow triggers now include:
- Pull requests (opened, synchronize, reopened) - for PR validation
- Push to develop branch - for deployment builds
- Push to tags - for release builds
- workflow_dispatch - for manual execution

🤖 Generated with [Claude Code](https://claude.ai/code)