### PR TITLE
Fix workflow run-name to show appropriate titles for different trigger types

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -1,5 +1,5 @@
 name: Build Backend
-run-name: "Build Backend : ${{ github.event.head_commit.message }}"
+run-name: "${{ github.workflow }} : ${{ github.event_name == 'pull_request' && github.event.pull_request.title || github.event.head_commit.message || 'Manual run' }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,5 +1,5 @@
 name: Build Frontend
-run-name: "Build Frontend : ${{ github.event.head_commit.message }}"
+run-name: "${{ github.workflow }} : ${{ github.event_name == 'pull_request' && github.event.pull_request.title || github.event.head_commit.message || 'Manual run' }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Fix workflow run-name to display appropriate titles based on trigger type
- Prevent empty run names when triggered by pull requests
- Use conditional expressions to handle different event contexts

## Changes
- Updated run-name in both build-backend.yml and build-frontend.yml
- Use conditional logic: PR title for pull_request events, commit message for push events, "Manual run" for workflow_dispatch

## Run-name behavior:
- **Pull Request**: "Build Backend : [PR Title]"
- **Push to develop/tags**: "Build Backend : [Commit Message]"
- **Manual execution**: "Build Backend : Manual run"

## Test plan
- [x] Verify PR run names show PR title
- [x] Verify push run names show commit message
- [x] Verify manual run names show "Manual run"

🤖 Generated with [Claude Code](https://claude.ai/code)