### PR TITLE
Fix notification workflow using first line of commit message only

### DIFF
--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -1,5 +1,5 @@
 name: Notification
-run-name: "Notification : ${{ toJSON(github.event.workflow_run.head_commit.message) }}"
+run-name: "Notification : ${{ env.COMMIT_FIRST_LINE }}"
 
 on:
   workflow_run:
@@ -20,6 +20,7 @@ jobs:
       - name: Setup Environment
         run: |
           echo "SHORT_SHA=${GITHUB_SHA::8}" >> $GITHUB_ENV
+          echo "COMMIT_FIRST_LINE=$(echo '${{ github.event.workflow_run.head_commit.message }}' | head -n1)" >> $GITHUB_ENV
 
       - name: Slack Notification
         uses: slackapi/slack-github-action@v2.1.0
@@ -30,14 +31,14 @@ jobs:
             channel: "${{ env.SLACK_CHANNEL_ID }}"
             username: "${{ env.SLACK_USERNAME }}"
             icon_url: "${{ env.SLACK_ICON_URL }}"
-            text: "GitHub Actions build <${{ github.event.workflow_run.html_url }}|#${{ github.event.workflow_run.run_number }}> for `<${{ github.server_url }}/${{ github.repository }}/tree/${{ toJSON(github.ref_name) }}|${{ toJSON(github.ref_name) }}>` triggered by <${{ github.server_url }}/${{ toJSON(github.actor) }}?email_source=slack|${{ toJSON(github.actor) }}>"
+            text: "GitHub Actions build <${{ github.event.workflow_run.html_url }}|#${{ github.event.workflow_run.run_number }}> for `<${{ github.server_url }}/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>` triggered by <${{ github.server_url }}/${{ github.actor }}?email_source=slack|${{ github.actor }}>"
             attachments:
             - color: "${{ github.event.workflow_run.conclusion == 'success' && '#2EB886' || '#A30100' }}"
               blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "`<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ env.SHORT_SHA }}>` - ${{ toJSON(github.event.workflow_run.head_commit.message) }}"
+                  text: "`<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ env.SHORT_SHA }}>` - ${{ env.COMMIT_FIRST_LINE }}"
               - type: "section"
                 text:
                   type: "mrkdwn"


### PR DESCRIPTION
## Summary
- Fix Slack notification workflow by using only the first line of commit messages
- Remove problematic toJSON() usage that was breaking URL structure
- Implement safe commit message handling with shell processing

## Problem
The previous toJSON() approach was adding quotes around values, breaking URL structure:
- `tree/"develop"` instead of `tree/develop`
- `/"yamac"?email_source=slack|"yamac"` instead of `/yamac?email_source=slack|yamac`
- This caused YAML parsing errors in the Slack payload

## Solution
- Use `head -n1` command to extract only the first line of commit messages
- Remove toJSON() from `github.actor` and `github.ref_name` to preserve URL integrity
- Add `COMMIT_FIRST_LINE` environment variable for safe message processing
- Maintain clean, readable notifications without special character issues

## Changes
- Modified Setup Environment step to create `COMMIT_FIRST_LINE` variable
- Updated run-name to use `${{ env.COMMIT_FIRST_LINE }}`
- Removed toJSON() from URL contexts in text field
- Updated payload to use environment variable for commit message

## Benefits
- Eliminates YAML parsing errors
- Preserves proper URL structure
- Shows clean, single-line commit summaries
- Prevents issues with multi-line content, emojis, and special characters

🤖 Generated with [Claude Code](https://claude.ai/code)