### PR TITLE
Fix notification workflow run-name env variable issue

### DIFF
--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -1,5 +1,5 @@
 name: Notification
-run-name: "Notification : ${{ env.COMMIT_FIRST_LINE }}"
+run-name: "Notification : ${{ github.event.workflow_run.display_title || 'Workflow completed' }}"
 
 on:
   workflow_run:


### PR DESCRIPTION
## Summary
- Fix workflow syntax error caused by using env variable in run-name
- Replace env.COMMIT_FIRST_LINE with github.event.workflow_run.display_title
- Maintain first-line commit message processing for payload content

## Problem
Previous attempt failed with error:
```
Unrecognized named-value: 'env'. Located at position 1 within expression: env.COMMIT_FIRST_LINE
```

**Root cause:** `run-name` is evaluated before job execution, so environment variables set in job steps are not available.

## Solution
- Use `github.event.workflow_run.display_title` for run-name (available at workflow level)
- Keep environment variable processing (`COMMIT_FIRST_LINE`) for payload content where it works correctly
- Provide fallback value for run-name in case display_title is unavailable

## Changes
- Updated run-name to use workflow context instead of env variable
- Maintained shell-based first-line processing for commit message in payload
- Preserved URL structure fixes (removed toJSON from actor/ref_name)

## Benefits
- Eliminates workflow syntax errors
- Shows meaningful run names using workflow display titles
- Keeps clean commit message handling in Slack payload
- Prevents YAML injection issues

🤖 Generated with [Claude Code](https://claude.ai/code)