### PR TITLE
Remove yamac-net- prefix from Kubernetes resource names

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -15,7 +15,7 @@ on:
       - v*
 
 env:
-  DOCKER_IMAGE_NAME: yamac-net-claude-code-todoapp/backend
+  DOCKER_IMAGE_NAME: claude-code-todoapp/backend
 
 jobs:
   build:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -15,7 +15,7 @@ on:
       - v*
 
 env:
-  DOCKER_IMAGE_NAME: yamac-net-claude-code-todoapp/frontend
+  DOCKER_IMAGE_NAME: claude-code-todoapp/frontend
 
 jobs:
   build:

--- a/backend/deployment/kubernetes/base/configmap.yaml
+++ b/backend/deployment/kubernetes/base/configmap.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: yamac-net-claude-code-todoapp-backend
+  name: claude-code-todoapp-backend

--- a/backend/deployment/kubernetes/base/deployment.yaml
+++ b/backend/deployment/kubernetes/base/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: yamac-net-claude-code-todoapp-backend
+  name: claude-code-todoapp-backend
 spec:
   selector:
     matchLabels:
-      app: yamac-net-claude-code-todoapp-backend
+      app: claude-code-todoapp-backend
   template:
     metadata:
       labels:
-        app: yamac-net-claude-code-todoapp-backend
+        app: claude-code-todoapp-backend
     spec:
       serviceAccountName: deployer
       containers:
-        - name: yamac-net-claude-code-todoapp-backend
+        - name: claude-code-todoapp-backend
           ports:
             - containerPort: 8080
           envFrom:
             - configMapRef:
-                name: yamac-net-claude-code-todoapp-backend
+                name: claude-code-todoapp-backend

--- a/backend/deployment/kubernetes/base/ingress.yaml
+++ b/backend/deployment/kubernetes/base/ingress.yaml
@@ -1,4 +1,4 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: yamac-net-claude-code-todoapp-backend
+  name: claude-code-todoapp-backend

--- a/backend/deployment/kubernetes/base/kustomization.yaml
+++ b/backend/deployment/kubernetes/base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 labels:
   - includeSelectors: true
     pairs:
-      app: yamac-net-claude-code-todoapp-backend
+      app: claude-code-todoapp-backend
 
 resources:
   - configmap.yaml

--- a/backend/deployment/kubernetes/base/service.yaml
+++ b/backend/deployment/kubernetes/base/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: yamac-net-claude-code-todoapp-backend
+  name: claude-code-todoapp-backend
 spec:
   selector:
-    app: yamac-net-claude-code-todoapp-backend
+    app: claude-code-todoapp-backend
   ports:
     - name: http
       port: 8080

--- a/backend/deployment/kubernetes/overlays/beta/configmap.yaml
+++ b/backend/deployment/kubernetes/overlays/beta/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: yamac-net-claude-code-todoapp-backend
+  name: claude-code-todoapp-backend
 data:
   SPRING_PROFILES_ACTIVE: beta

--- a/backend/deployment/kubernetes/overlays/beta/deployment.yaml
+++ b/backend/deployment/kubernetes/overlays/beta/deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: yamac-net-claude-code-todoapp-backend
+  name: claude-code-todoapp-backend
 spec:
   replicas: 1
   template:
     spec:
       containers:
-        - name: yamac-net-claude-code-todoapp-backend
-          image: cr.yamac.net/yamac-net-claude-code-todoapp/backend:develop
+        - name: claude-code-todoapp-backend
+          image: cr.yamac.net/claude-code-todoapp/backend:develop
           imagePullPolicy: Always
           resources:
             requests:

--- a/backend/deployment/kubernetes/overlays/beta/ingress.yaml
+++ b/backend/deployment/kubernetes/overlays/beta/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: yamac-net-claude-code-todoapp-backend
+  name: claude-code-todoapp-backend
 spec:
   tls:
     - hosts:
@@ -15,6 +15,6 @@ spec:
             path: /
             backend:
               service:
-                name: yamac-net-claude-code-todoapp-backend
+                name: claude-code-todoapp-backend
                 port:
                   number: 8080

--- a/frontend/deployment/kubernetes/base/configmap.yaml
+++ b/frontend/deployment/kubernetes/base/configmap.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: yamac-net-claude-code-todoapp-frontend
+  name: claude-code-todoapp-frontend

--- a/frontend/deployment/kubernetes/base/deployment.yaml
+++ b/frontend/deployment/kubernetes/base/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: yamac-net-claude-code-todoapp-frontend
+  name: claude-code-todoapp-frontend
 spec:
   selector:
     matchLabels:
-      app: yamac-net-claude-code-todoapp-frontend
+      app: claude-code-todoapp-frontend
   template:
     metadata:
       labels:
-        app: yamac-net-claude-code-todoapp-frontend
+        app: claude-code-todoapp-frontend
     spec:
       serviceAccountName: deployer
       containers:
-        - name: yamac-net-claude-code-todoapp-frontend
+        - name: claude-code-todoapp-frontend
           ports:
             - containerPort: 80
           envFrom:
             - configMapRef:
-                name: yamac-net-claude-code-todoapp-frontend
+                name: claude-code-todoapp-frontend

--- a/frontend/deployment/kubernetes/base/ingress.yaml
+++ b/frontend/deployment/kubernetes/base/ingress.yaml
@@ -1,4 +1,4 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: yamac-net-claude-code-todoapp-frontend
+  name: claude-code-todoapp-frontend

--- a/frontend/deployment/kubernetes/base/kustomization.yaml
+++ b/frontend/deployment/kubernetes/base/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 labels:
   - includeSelectors: true
     pairs:
-      app: yamac-net-claude-code-todoapp-frontend
+      app: claude-code-todoapp-frontend
 
 resources:
   - configmap.yaml

--- a/frontend/deployment/kubernetes/base/service.yaml
+++ b/frontend/deployment/kubernetes/base/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: yamac-net-claude-code-todoapp-frontend
+  name: claude-code-todoapp-frontend
 spec:
   selector:
-    app: yamac-net-claude-code-todoapp-frontend
+    app: claude-code-todoapp-frontend
   ports:
     - name: http
       port: 80

--- a/frontend/deployment/kubernetes/overlays/beta/configmap.yaml
+++ b/frontend/deployment/kubernetes/overlays/beta/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: yamac-net-claude-code-todoapp-frontend
+  name: claude-code-todoapp-frontend
 data:
   REACT_APP_API_BASE_URL: https://claude-code-todoapp-api.yamac-beta.net

--- a/frontend/deployment/kubernetes/overlays/beta/deployment.yaml
+++ b/frontend/deployment/kubernetes/overlays/beta/deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: yamac-net-claude-code-todoapp-frontend
+  name: claude-code-todoapp-frontend
 spec:
   replicas: 1
   template:
     spec:
       containers:
-        - name: yamac-net-claude-code-todoapp-frontend
-          image: cr.yamac.net/yamac-net-claude-code-todoapp/frontend:develop
+        - name: claude-code-todoapp-frontend
+          image: cr.yamac.net/claude-code-todoapp/frontend:develop
           imagePullPolicy: Always
           resources:
             requests:

--- a/frontend/deployment/kubernetes/overlays/beta/ingress.yaml
+++ b/frontend/deployment/kubernetes/overlays/beta/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: yamac-net-claude-code-todoapp-frontend
+  name: claude-code-todoapp-frontend
 spec:
   tls:
     - hosts:
@@ -15,6 +15,6 @@ spec:
             path: /
             backend:
               service:
-                name: yamac-net-claude-code-todoapp-frontend
+                name: claude-code-todoapp-frontend
                 port:
                   number: 80


### PR DESCRIPTION
## Summary
- Simplify Kubernetes resource naming by removing unnecessary yamac-net- prefix
- Update all metadata names, labels, selectors, and references consistently
- Maintain functionality while using cleaner resource names

## Changes
**Resource Names Updated:**
- `yamac-net-claude-code-todoapp-backend` → `claude-code-todoapp-backend`
- `yamac-net-claude-code-todoapp-frontend` → `claude-code-todoapp-frontend`

**Docker Image Paths Updated:**
- `cr.yamac.net/yamac-net-claude-code-todoapp/backend` → `cr.yamac.net/claude-code-todoapp/backend`
- `cr.yamac.net/yamac-net-claude-code-todoapp/frontend` → `cr.yamac.net/claude-code-todoapp/frontend`

## Files Modified (16 total)
**Backend (8 files):**
- `backend/deployment/kubernetes/base/` (configmap, deployment, ingress, service, kustomization)
- `backend/deployment/kubernetes/overlays/beta/` (configmap, deployment, ingress)

**Frontend (8 files):**
- `frontend/deployment/kubernetes/base/` (configmap, deployment, ingress, service, kustomization)  
- `frontend/deployment/kubernetes/overlays/beta/` (configmap, deployment, ingress)

## Verification
- ✅ All cross-references between resources updated consistently
- ✅ Kustomize build tested for both backend and frontend beta overlays
- ✅ No broken references or missing labels
- ✅ ArgoCD deployments will need to be updated to use new resource names

🤖 Generated with [Claude Code](https://claude.ai/code)