### PR TITLE
Remove unnecessary chmod from backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,10 +3,10 @@ WORKDIR /backend
 COPY . /backend
 
 FROM base AS test
-RUN chmod +x ./gradlew && ./gradlew clean test
+RUN ./gradlew clean test
 
 FROM base AS build
-RUN chmod +x ./gradlew && ./gradlew clean build
+RUN ./gradlew clean build
 
 FROM cr-mirror.yamac.net/library/eclipse-temurin:21-jre-alpine AS package-app
 WORKDIR /App


### PR DESCRIPTION
## Summary
- Remove unnecessary `chmod +x ./gradlew` commands from Dockerfile
- Git preserves file permissions, so gradlew already has execute permissions

## Changes
- Cleaned up test and build stages in backend/Dockerfile
- Reduced build steps and improved readability

🤖 Generated with [Claude Code](https://claude.ai/code)