### PR TITLE
Add SealedSecret support for DB_PASSWORD injection

### DIFF
--- a/backend/deployment/kubernetes/base/deployment.yaml
+++ b/backend/deployment/kubernetes/base/deployment.yaml
@@ -19,3 +19,5 @@ spec:
           envFrom:
             - configMapRef:
                 name: claude-code-todoapp-backend
+            - secretRef:
+                name: claude-code-todoapp-backend

--- a/backend/deployment/kubernetes/overlays/beta/kustomization.yaml
+++ b/backend/deployment/kubernetes/overlays/beta/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: app-beta
 
 resources:
   - ./../../base
+  - sealed-secret.yaml
 
 patches:
   - path: configmap.yaml

--- a/backend/deployment/kubernetes/overlays/beta/sealed-secret.yaml
+++ b/backend/deployment/kubernetes/overlays/beta/sealed-secret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: claude-code-todoapp-backend
+  namespace: app-beta
+spec:
+  encryptedData:
+    DB_PASSWORD: AgCkv3eb0v0cDvs+LJSATfJH5QFN+UJ28lVzh8QEFY9ZWOV09VDekT1DxUmxgh9Te6EHWlZgnfWLg3OtAivDRihWaq3OQG6FJr2bd9/k+fJm5uTvkzSFPPdAHKvpjbfP+wCPXiQxwkMmVR1iXuwGd2/Oupymwx8h7V14msAi/yCBTc8ygj5w1r08MTn21Gw2BPlP8U+LZgFQQs/V6nKOXOVjWU3Hxq+jLWX0OVw6CNSKS1fXv39cqYgKQ/cY9YW484MITdhHHWR8rnW0tNJnCKv3lYIK1dQBR/yczaDhWDCii2qPbBPHy+fPXLqXW815vM/IXNOQ4fYAgJtoerHhjcr0QS7s6SzzFfVAbiQMdxF2ZB8ZfMtFDyUx2Z/a1lzI1XCQLgymrrSUCXcPOtXgne6hO47u2i3Fdl5tZ00l4YB039uG2ve/n66WjJOsGflWtfsMhXRsAuKGMgyCteAaxF8iY/yHNcfK4n4UCF+XfCp+hSqt+b3vD4CikvRtJ19Es42mftPEc5BMUluZXTUCXi5zjCXk/uFPxtgqOzmeuBMXTYTY8yddiJ19O4Rchnne5/8ZNv/QE/mqgfTBrf9jDfTq/oGliapaGdc0OrT1DG4qKjx9PyQ7cMRtLq1VtXmF51AzC1/vXkbrUdHBNMrFyZMbEup1I73d98lae1szDKGdIc7Wj6OAu1T5Zjb9Zd7fxIAJ7iX/UnXqxu+0rmTYs6QU
+  template:
+    metadata:
+      creationTimestamp: null
+      name: claude-code-todoapp-backend
+      namespace: app-beta
+    type: Opaque


### PR DESCRIPTION
## Summary
- Add SealedSecret configuration for secure DB_PASSWORD management in beta environment
- Update Kubernetes deployment to inject database credentials from Secret

## Changes
- **sealed-secret.yaml**: Add SealedSecret resource with encrypted DB_PASSWORD
- **base/deployment.yaml**: Add secretRef to envFrom for environment variable injection  
- **beta/kustomization.yaml**: Include SealedSecret in Kustomize build

## Benefits
- Secure storage of database passwords using SealedSecret encryption
- Proper separation of configuration (ConfigMap) and secrets (Secret)
- Beta environment can now connect to MySQL with encrypted credentials

🤖 Generated with [Claude Code](https://claude.ai/code)