### PR TITLE
Add build status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # TODO App
 
+[![Backend Build](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/backend-build.yml/badge.svg)](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/backend-build.yml)
+[![Frontend Build](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/frontend-build.yml/badge.svg)](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/frontend-build.yml)
+
 A full-stack TODO application with separated frontend and backend architecture.
 
 ## Architecture


### PR DESCRIPTION
## Summary
- Add GitHub Actions build status badges for backend and frontend
- Provides visibility into the current build status of each component

🤖 Generated with [Claude Code](https://claude.ai/code)