### PR TITLE
Fix workflow badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TODO App
 
-[![Backend Build](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/backend-build.yml/badge.svg)](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/backend-build.yml)
-[![Frontend Build](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/frontend-build.yml/badge.svg)](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/frontend-build.yml)
+[![Backend Build](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/build-backend.yml/badge.svg)](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/build-backend.yml)
+[![Frontend Build](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/build-frontend.yml/badge.svg)](https://github.com/yamac-net/claude-code-todoapp/actions/workflows/build-frontend.yml)
 
 A full-stack TODO application with separated frontend and backend architecture.
 


### PR DESCRIPTION
## Summary
- Fix workflow badge URLs to match actual workflow file names
- Changed from `backend-build.yml` to `build-backend.yml`
- Changed from `frontend-build.yml` to `build-frontend.yml`

## Test plan
- [x] Verify badges now display correctly (no more "Not Found")
- [x] Confirm badges link to the correct workflow runs

🤖 Generated with [Claude Code](https://claude.ai/code)