### PR TITLE
Reduce backend beta deployment memory limit

### DIFF
--- a/backend/deployment/kubernetes/overlays/beta/deployment.yaml
+++ b/backend/deployment/kubernetes/overlays/beta/deployment.yaml
@@ -14,4 +14,4 @@ spec:
             requests:
               memory: 100Mi
             limits:
-              memory: 300Mi
+              memory: 200Mi


### PR DESCRIPTION
## Summary
- Reduce backend beta deployment memory limit from 300Mi to 200Mi
- Keep memory request at 100Mi
- This optimization helps reduce memory usage in the beta environment

## Test plan
- [x] Deploy to beta environment
- [x] Monitor memory usage to ensure application runs within new limits
- [x] Verify no OOM (Out of Memory) errors occur

🤖 Generated with [Claude Code](https://claude.ai/code)