### PR TITLE
Revert "Reduce backend beta deployment memory limit"

### DIFF
--- a/backend/deployment/kubernetes/overlays/beta/deployment.yaml
+++ b/backend/deployment/kubernetes/overlays/beta/deployment.yaml
@@ -14,4 +14,4 @@ spec:
             requests:
               memory: 100Mi
             limits:
-              memory: 200Mi
+              memory: 300Mi


### PR DESCRIPTION
## Summary
Reverts yamac-net/claude-code-todoapp#20

This reverts the memory limit reduction from 300Mi to 200Mi as it caused OOM (Out of Memory) errors in the beta environment.

## Reason for revert
- OOM errors occurred after deploying the memory limit reduction
- The application requires more than 200Mi of memory to run properly

## Changes
- Restores memory limit back to 300Mi
- Keeps memory request at 100Mi

🤖 Generated with [Claude Code](https://claude.ai/code)