### PR TITLE
Fix notification workflow to handle quotes in commit messages

### DIFF
--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Setup Environment
         run: |
           echo "SHORT_SHA=${GITHUB_SHA::8}" >> $GITHUB_ENV
-          echo "COMMIT_FIRST_LINE=$(echo '${{ github.event.workflow_run.head_commit.message }}' | head -n1)" >> $GITHUB_ENV
+          # Use printf to properly handle quotes and special characters
+          COMMIT_MSG=$(printf '%s' '${{ github.event.workflow_run.head_commit.message }}' | head -n1 | sed 's/"/\\"/g')
+          echo "COMMIT_FIRST_LINE=$COMMIT_MSG" >> $GITHUB_ENV
 
       - name: Slack Notification
         uses: slackapi/slack-github-action@v2.1.0


### PR DESCRIPTION
## Summary
- Fix notification workflow parsing error when commit messages contain double quotes
- Use proper escaping with sed to handle quotes in commit messages
- This addresses the failure in workflow run #15856821751

## Problem
The notification workflow was failing with "Invalid input\! Failed to parse contents of the provided payload" when commit messages contained double quotes (e.g., revert commits with titles like `Revert "Some change"`).

## Solution
- Replace direct echo with printf and sed to properly escape quotes
- Use `sed 's/"/\\"/g'` to escape double quotes in commit messages
- This prevents JSON parsing errors in the Slack payload

## Test
This commit message itself contains "quotes" to test the fix.

🤖 Generated with [Claude Code](https://claude.ai/code)