### PR TITLE
Configure dependabot to ignore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
     labels:
       - "dependencies"
       - "gradle"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/frontend"
@@ -35,6 +38,9 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Summary
- Configure dependabot to ignore major version updates for all dependencies
- Prevents automatic PRs for breaking changes (e.g., TypeScript 4.x → 5.x, Spring Boot 3.x → 4.x)
- Only minor and patch version updates will be automatically proposed

## Changes
- Backend (Gradle): Ignore all `version-update:semver-major` updates
- Frontend (npm): Ignore all `version-update:semver-major` updates  
- Docker: No restrictions (low risk of breaking changes)

## Rationale
- Major version updates often contain breaking changes requiring careful evaluation
- Recent TypeScript 5.x update failed due to react-scripts compatibility
- Allows manual control over when to adopt major version updates

## Test plan
- [x] Verify dependabot.yml syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)